### PR TITLE
Forcing the use of UTF-8 for file I/O to fix errors on Centos 7

### DIFF
--- a/vhdmmio/configurable/configurable.py
+++ b/vhdmmio/configurable/configurable.py
@@ -117,7 +117,7 @@ class Configurable:
         if isinstance(obj, str):
             if obj.lower().endswith('.json'):
                 loader = json.loads
-            with open(obj, 'r') as fil:
+            with open(obj, 'r', encoding="utf-8") as fil:
                 return cls(
                     parent, loader(fil.read()),
                     source_file=obj)
@@ -148,7 +148,7 @@ class Configurable:
             data = dumper(data, default_flow_style=False)
 
         if isinstance(obj, str):
-            with open(obj, 'w') as fil:
+            with open(obj, 'w', encoding="utf-8") as fil:
                 fil.write(data)
             return None
 

--- a/vhdmmio/template.py
+++ b/vhdmmio/template.py
@@ -133,7 +133,7 @@ class TemplateEngine:
         result to the given output file. Extra arguments are passed to
         `apply_str_to_str()` and are documented there."""
         output = self.apply_file_to_str(template_filename, *args, **kwargs)
-        with open(output_filename, 'w') as output_file:
+        with open(output_filename, 'w', encoding="utf-8") as output_file:
             output_file.write(output)
 
     def apply_str_to_file(self, template, output_filename, *args, **kwargs):
@@ -141,14 +141,14 @@ class TemplateEngine:
         result to the given output file. Extra arguments are passed to
         `apply_str_to_str()` and are documented there."""
         output = self.apply_str_to_str(template, *args, **kwargs)
-        with open(output_filename, 'w') as output_file:
+        with open(output_filename, 'w', encoding="utf-8") as output_file:
             output_file.write(output)
 
     def apply_file_to_str(self, template_filename, *args, **kwargs):
         """Applies this template engine to the given template file, returning
         the result as a string. Extra arguments are passed to
         `apply_str_to_str()` and are documented there."""
-        with open(template_filename, 'r') as template_file:
+        with open(template_filename, 'r', encoding="utf-8") as template_file:
             template = annotate_block(
                 template_file.read(),
                 template_filename,
@@ -784,7 +784,7 @@ def preload_template(fname, comment='#'):
         caller_fname, _, _, _, _ = inspect.getframeinfo(previous_frame)
         fname = os.path.dirname(caller_fname) + os.sep + fname
 
-    with open(fname, 'r') as fil:
+    with open(fname, 'r', encoding="utf-8") as fil:
         template = fil.read()
 
     return annotate_block(template, fname, comment)


### PR DESCRIPTION
I don't know if you'd want to force UTF8 at all of these spots, or if there is even a more elegant way to handle this, but this fixes this type of errors for me on Centos 7:
```
UnicodeEncodeError: 'ascii' codec can't encode character '\u2026' in position 2658: ordinal not in range(128)
```
